### PR TITLE
Create Domain Events

### DIFF
--- a/app/Domain/Event/WithdrawCompleted.php
+++ b/app/Domain/Event/WithdrawCompleted.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Event;
+
+use App\Domain\Entity\Account;
+use App\Domain\Entity\AccountWithdraw;
+use DateTimeImmutable;
+
+final readonly class WithdrawCompleted implements DomainEvent
+{
+    private DateTimeImmutable $occurredAt;
+
+    public function __construct(
+        private AccountWithdraw $withdraw,
+        private Account $account
+    ) {
+        $this->occurredAt = new DateTimeImmutable();
+    }
+
+    public function withdraw(): AccountWithdraw
+    {
+        return $this->withdraw;
+    }
+
+    public function account(): Account
+    {
+        return $this->account;
+    }
+
+    public function occurredAt(): DateTimeImmutable
+    {
+        return $this->occurredAt;
+    }
+}

--- a/app/Domain/Event/WithdrawFailed.php
+++ b/app/Domain/Event/WithdrawFailed.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Event;
+
+use App\Domain\Entity\AccountWithdraw;
+use DateTimeImmutable;
+
+final readonly class WithdrawFailed implements DomainEvent
+{
+    private DateTimeImmutable $occurredAt;
+
+    public function __construct(
+        private AccountWithdraw $withdraw,
+        private string $reason
+    ) {
+        $this->occurredAt = new DateTimeImmutable();
+    }
+
+    public function withdraw(): AccountWithdraw
+    {
+        return $this->withdraw;
+    }
+
+    public function reason(): string
+    {
+        return $this->reason;
+    }
+
+    public function occurredAt(): DateTimeImmutable
+    {
+        return $this->occurredAt;
+    }
+}

--- a/test/Unit/Domain/Event/WithdrawCompletedTest.php
+++ b/test/Unit/Domain/Event/WithdrawCompletedTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Domain\Event;
+
+use App\Domain\Entity\Account;
+use App\Domain\Entity\AccountWithdraw;
+use App\Domain\Enum\WithdrawMethod;
+use App\Domain\Event\DomainEvent;
+use App\Domain\Event\WithdrawCompleted;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\Uuid;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class WithdrawCompletedTest extends TestCase
+{
+    #[Test]
+    public function implementsDomainEventInterface(): void
+    {
+        $event = $this->createEvent();
+
+        $this->assertInstanceOf(DomainEvent::class, $event);
+    }
+
+    #[Test]
+    public function carriesWithdrawData(): void
+    {
+        $withdraw = $this->createWithdraw();
+        $account = $this->createAccount();
+
+        $event = new WithdrawCompleted($withdraw, $account);
+
+        $this->assertSame($withdraw, $event->withdraw());
+        $this->assertSame($account, $event->account());
+    }
+
+    #[Test]
+    public function occurredAtIsSet(): void
+    {
+        $event = $this->createEvent();
+
+        $this->assertNotNull($event->occurredAt());
+    }
+
+    private function createEvent(): WithdrawCompleted
+    {
+        return new WithdrawCompleted($this->createWithdraw(), $this->createAccount());
+    }
+
+    private function createWithdraw(): AccountWithdraw
+    {
+        return AccountWithdraw::createImmediate(
+            Uuid::generate(),
+            Uuid::generate(),
+            WithdrawMethod::PIX,
+            Money::fromFloat(100.00)
+        );
+    }
+
+    private function createAccount(): Account
+    {
+        return Account::create(Uuid::generate(), 'John Doe', Money::fromFloat(1000.00));
+    }
+}

--- a/test/Unit/Domain/Event/WithdrawFailedTest.php
+++ b/test/Unit/Domain/Event/WithdrawFailedTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Domain\Event;
+
+use App\Domain\Entity\AccountWithdraw;
+use App\Domain\Enum\WithdrawMethod;
+use App\Domain\Event\DomainEvent;
+use App\Domain\Event\WithdrawFailed;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\Uuid;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class WithdrawFailedTest extends TestCase
+{
+    #[Test]
+    public function implementsDomainEventInterface(): void
+    {
+        $event = $this->createEvent();
+
+        $this->assertInstanceOf(DomainEvent::class, $event);
+    }
+
+    #[Test]
+    public function carriesWithdrawAndReason(): void
+    {
+        $withdraw = $this->createWithdraw();
+        $reason = 'Insufficient balance';
+
+        $event = new WithdrawFailed($withdraw, $reason);
+
+        $this->assertSame($withdraw, $event->withdraw());
+        $this->assertSame('Insufficient balance', $event->reason());
+    }
+
+    #[Test]
+    public function occurredAtIsSet(): void
+    {
+        $event = $this->createEvent();
+
+        $this->assertNotNull($event->occurredAt());
+    }
+
+    private function createEvent(): WithdrawFailed
+    {
+        return new WithdrawFailed($this->createWithdraw(), 'Insufficient balance');
+    }
+
+    private function createWithdraw(): AccountWithdraw
+    {
+        return AccountWithdraw::createImmediate(
+            Uuid::generate(),
+            Uuid::generate(),
+            WithdrawMethod::PIX,
+            Money::fromFloat(100.00)
+        );
+    }
+}


### PR DESCRIPTION
Closes #25 

This pull request introduces two new domain events for handling withdrawal operations, along with corresponding unit tests to ensure their correctness. The main changes are the addition of the `WithdrawCompleted` and `WithdrawFailed` event classes, which encapsulate data about successful and failed withdrawals, respectively.

**Domain Event Additions:**

* Added the `WithdrawCompleted` event class to represent a successful withdrawal, storing the associated `AccountWithdraw`, `Account`, and the time of occurrence. (`app/Domain/Event/WithdrawCompleted.php`)
* Added the `WithdrawFailed` event class to represent a failed withdrawal, storing the associated `AccountWithdraw`, failure reason, and the time of occurrence. (`app/Domain/Event/WithdrawFailed.php`)

**Unit Testing:**

* Created `WithdrawCompletedTest` to verify that the `WithdrawCompleted` event implements the `DomainEvent` interface, carries the correct withdrawal and account data, and sets the occurrence time. (`test/Unit/Domain/Event/WithdrawCompletedTest.php`)
* Created `WithdrawFailedTest` to verify that the `WithdrawFailed` event implements the `DomainEvent` interface, carries the correct withdrawal and reason data, and sets the occurrence time. (`test/Unit/Domain/Event/WithdrawFailedTest.php`)