### PR TITLE
Create Strategy Pattern for withdraw methods

### DIFF
--- a/app/Domain/Entity/Account.php
+++ b/app/Domain/Entity/Account.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Domain\Entity;
 
 use App\Domain\Exception\InsufficientBalanceException;
+use App\Domain\Exception\InvalidAmountException;
 use App\Domain\ValueObject\Money;
 use App\Domain\ValueObject\Uuid;
-use InvalidArgumentException;
 
 class Account
 {
@@ -26,7 +26,7 @@ class Account
     public function withdraw(Money $amount): void
     {
         if ($amount->isZero()) {
-            throw new InvalidArgumentException('Withdraw amount must be greater than zero');
+            throw InvalidAmountException::mustBePositive();
         }
 
         if (! $this->balance->isGreaterThanOrEqual($amount)) {

--- a/app/Domain/Enum/PixKeyType.php
+++ b/app/Domain/Enum/PixKeyType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Enum;
 
-use InvalidArgumentException;
+use App\Domain\Exception\InvalidPixDataException;
 
 enum PixKeyType: string
 {
@@ -13,7 +13,7 @@ enum PixKeyType: string
     public function validate(string $key): void
     {
         if ($key === '') {
-            throw new InvalidArgumentException('PIX key cannot be empty');
+            throw InvalidPixDataException::emptyKey();
         }
 
         match ($this) {
@@ -24,7 +24,7 @@ enum PixKeyType: string
     private static function validateEmail(string $key): void
     {
         if (filter_var($key, FILTER_VALIDATE_EMAIL) === false) {
-            throw new InvalidArgumentException("Invalid email for PIX key: {$key}");
+            throw InvalidPixDataException::invalidEmail($key);
         }
     }
 }

--- a/app/Domain/Exception/InvalidAmountException.php
+++ b/app/Domain/Exception/InvalidAmountException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exception;
+
+class InvalidAmountException extends BusinessException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function negative(): self
+    {
+        return new self('Money cannot be negative');
+    }
+
+    public static function tooManyDecimals(): self
+    {
+        return new self('Money must have at most 2 decimal places');
+    }
+
+    public static function invalidFormat(string $value): self
+    {
+        return new self("Invalid money format: {$value}");
+    }
+
+    public static function mustBePositive(): self
+    {
+        return new self('Withdraw amount must be greater than zero');
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'INVALID_AMOUNT';
+    }
+}

--- a/app/Domain/Exception/InvalidPixDataException.php
+++ b/app/Domain/Exception/InvalidPixDataException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exception;
+
+class InvalidPixDataException extends BusinessException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function emptyKey(): self
+    {
+        return new self('PIX key cannot be empty');
+    }
+
+    public static function invalidType(string $type): self
+    {
+        return new self("Invalid PIX key type: {$type}");
+    }
+
+    public static function invalidEmail(string $key): self
+    {
+        return new self("Invalid email for PIX key: {$key}");
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'INVALID_PIX_DATA';
+    }
+}

--- a/app/Domain/Exception/InvalidUuidException.php
+++ b/app/Domain/Exception/InvalidUuidException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exception;
+
+class InvalidUuidException extends BusinessException
+{
+    public function __construct(string $value)
+    {
+        parent::__construct("Invalid UUID format: {$value}");
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'INVALID_UUID';
+    }
+
+    public function getHttpStatusCode(): int
+    {
+        return 400;
+    }
+}

--- a/app/Domain/Strategy/PixWithdrawData.php
+++ b/app/Domain/Strategy/PixWithdrawData.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Strategy;
+
+use App\Domain\ValueObject\PixKey;
+
+final readonly class PixWithdrawData implements WithdrawMethodData
+{
+    public function __construct(private PixKey $pixKey)
+    {
+    }
+
+    public function getPixKey(): PixKey
+    {
+        return $this->pixKey;
+    }
+}

--- a/app/Domain/Strategy/PixWithdrawStrategy.php
+++ b/app/Domain/Strategy/PixWithdrawStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Strategy;
+
+use App\Domain\ValueObject\PixKey;
+
+final class PixWithdrawStrategy implements WithdrawMethodStrategyInterface
+{
+    public function validateAndBuild(array $data): WithdrawMethodData
+    {
+        return new PixWithdrawData(
+            PixKey::create($data['type'] ?? '', $data['key'] ?? '')
+        );
+    }
+}

--- a/app/Domain/Strategy/WithdrawMethodData.php
+++ b/app/Domain/Strategy/WithdrawMethodData.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Strategy;
+
+interface WithdrawMethodData
+{
+}

--- a/app/Domain/Strategy/WithdrawMethodStrategyInterface.php
+++ b/app/Domain/Strategy/WithdrawMethodStrategyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Strategy;
+
+interface WithdrawMethodStrategyInterface
+{
+    public function validateAndBuild(array $data): WithdrawMethodData;
+}

--- a/app/Domain/ValueObject/Money.php
+++ b/app/Domain/ValueObject/Money.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\ValueObject;
 
+use App\Domain\Exception\InvalidAmountException;
 use InvalidArgumentException;
 
 final readonly class Money
@@ -20,11 +21,11 @@ final readonly class Money
     public static function fromFloat(float $value): self
     {
         if ($value < 0) {
-            throw new InvalidArgumentException('Money cannot be negative');
+            throw InvalidAmountException::negative();
         }
 
         if (round($value, 2) != $value) {
-            throw new InvalidArgumentException('Money must have at most 2 decimal places');
+            throw InvalidAmountException::tooManyDecimals();
         }
 
         return new self((int) round($value * 100));
@@ -33,7 +34,7 @@ final readonly class Money
     public static function fromString(string $value): self
     {
         if (! preg_match('/^\d+(\.\d{1,2})?$/', $value)) {
-            throw new InvalidArgumentException("Invalid money format: {$value}");
+            throw InvalidAmountException::invalidFormat($value);
         }
 
         $parts = explode('.', $value);

--- a/app/Domain/ValueObject/PixKey.php
+++ b/app/Domain/ValueObject/PixKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\ValueObject;
 
 use App\Domain\Enum\PixKeyType;
-use InvalidArgumentException;
+use App\Domain\Exception\InvalidPixDataException;
 
 final readonly class PixKey
 {
@@ -20,7 +20,7 @@ final readonly class PixKey
         $normalizedType = strtolower($type);
 
         $pixKeyType = PixKeyType::tryFrom($normalizedType)
-            ?? throw new InvalidArgumentException("Invalid PIX key type: {$type}");
+            ?? throw InvalidPixDataException::invalidType($type);
 
         $key = trim($key);
 

--- a/app/Domain/ValueObject/Uuid.php
+++ b/app/Domain/ValueObject/Uuid.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\ValueObject;
 
-use InvalidArgumentException;
+use App\Domain\Exception\InvalidUuidException;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 use Ramsey\Uuid\UuidInterface;
 
@@ -22,9 +22,7 @@ final readonly class Uuid
     public static function fromString(string $value): self
     {
         if (! RamseyUuid::isValid($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Invalid UUID format: %s', $value)
-            );
+            throw new InvalidUuidException($value);
         }
 
         return new self(RamseyUuid::fromString($value));

--- a/test/Unit/Domain/Entity/AccountTest.php
+++ b/test/Unit/Domain/Entity/AccountTest.php
@@ -6,9 +6,9 @@ namespace HyperfTest\Unit\Domain\Entity;
 
 use App\Domain\Entity\Account;
 use App\Domain\Exception\InsufficientBalanceException;
+use App\Domain\Exception\InvalidAmountException;
 use App\Domain\ValueObject\Money;
 use App\Domain\ValueObject\Uuid;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -103,7 +103,7 @@ class AccountTest extends TestCase
     {
         $account = Account::create(Uuid::generate(), 'John Doe', Money::fromFloat(100.00));
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidAmountException::class);
         $this->expectExceptionMessage('Withdraw amount must be greater than zero');
 
         $account->withdraw(Money::zero());

--- a/test/Unit/Domain/Enum/PixKeyTypeTest.php
+++ b/test/Unit/Domain/Enum/PixKeyTypeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace HyperfTest\Unit\Domain\Enum;
 
 use App\Domain\Enum\PixKeyType;
-use InvalidArgumentException;
+use App\Domain\Exception\InvalidPixDataException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -27,7 +27,7 @@ class PixKeyTypeTest extends TestCase
     #[Test]
     public function emailThrowsOnInvalidFormat(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
         $this->expectExceptionMessage('Invalid email for PIX key');
 
         PixKeyType::EMAIL->validate('not-an-email');
@@ -36,7 +36,7 @@ class PixKeyTypeTest extends TestCase
     #[Test]
     public function emailThrowsOnEmptyKey(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
         $this->expectExceptionMessage('PIX key cannot be empty');
 
         PixKeyType::EMAIL->validate('');
@@ -45,7 +45,7 @@ class PixKeyTypeTest extends TestCase
     #[Test]
     public function emailThrowsOnMissingDomain(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
         $this->expectExceptionMessage('Invalid email for PIX key');
 
         PixKeyType::EMAIL->validate('someone@');
@@ -54,7 +54,7 @@ class PixKeyTypeTest extends TestCase
     #[Test]
     public function emailThrowsOnMissingLocalPart(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
         $this->expectExceptionMessage('Invalid email for PIX key');
 
         PixKeyType::EMAIL->validate('@email.com');

--- a/test/Unit/Domain/Strategy/PixWithdrawStrategyTest.php
+++ b/test/Unit/Domain/Strategy/PixWithdrawStrategyTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Domain\Strategy;
+
+use App\Domain\Enum\PixKeyType;
+use App\Domain\Exception\InvalidPixDataException;
+use App\Domain\Strategy\PixWithdrawData;
+use App\Domain\Strategy\PixWithdrawStrategy;
+use App\Domain\Strategy\WithdrawMethodData;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class PixWithdrawStrategyTest extends TestCase
+{
+    private PixWithdrawStrategy $strategy;
+
+    protected function setUp(): void
+    {
+        $this->strategy = new PixWithdrawStrategy();
+    }
+
+    // -- Valid PIX email --
+
+    #[Test]
+    public function validateAndBuildReturnsPixWithdrawDataForValidEmail(): void
+    {
+        $result = $this->strategy->validateAndBuild([
+            'type' => 'email',
+            'key' => 'fulano@email.com',
+        ]);
+
+        $this->assertInstanceOf(WithdrawMethodData::class, $result);
+        $this->assertInstanceOf(PixWithdrawData::class, $result);
+    }
+
+    #[Test]
+    public function pixWithdrawDataExposesPixKey(): void
+    {
+        /** @var PixWithdrawData $result */
+        $result = $this->strategy->validateAndBuild([
+            'type' => 'email',
+            'key' => 'fulano@email.com',
+        ]);
+
+        $this->assertSame(PixKeyType::EMAIL, $result->getPixKey()->type());
+        $this->assertSame('fulano@email.com', $result->getPixKey()->key());
+    }
+
+    // -- Invalid type --
+
+    #[Test]
+    public function throwsOnUnsupportedPixType(): void
+    {
+        $this->expectException(InvalidPixDataException::class);
+        $this->expectExceptionMessage('Invalid PIX key type: phone');
+
+        $this->strategy->validateAndBuild([
+            'type' => 'phone',
+            'key' => '+5511999999999',
+        ]);
+    }
+
+    #[Test]
+    public function throwsOnMissingType(): void
+    {
+        $this->expectException(InvalidPixDataException::class);
+        $this->expectExceptionMessage('Invalid PIX key type');
+
+        $this->strategy->validateAndBuild([
+            'key' => 'fulano@email.com',
+        ]);
+    }
+
+    #[Test]
+    public function throwsOnEmptyType(): void
+    {
+        $this->expectException(InvalidPixDataException::class);
+        $this->expectExceptionMessage('Invalid PIX key type');
+
+        $this->strategy->validateAndBuild([
+            'type' => '',
+            'key' => 'fulano@email.com',
+        ]);
+    }
+
+    // -- Missing key --
+
+    #[Test]
+    public function throwsOnMissingKey(): void
+    {
+        $this->expectException(InvalidPixDataException::class);
+        $this->expectExceptionMessage('PIX key cannot be empty');
+
+        $this->strategy->validateAndBuild([
+            'type' => 'email',
+        ]);
+    }
+
+    #[Test]
+    public function throwsOnEmptyKey(): void
+    {
+        $this->expectException(InvalidPixDataException::class);
+        $this->expectExceptionMessage('PIX key cannot be empty');
+
+        $this->strategy->validateAndBuild([
+            'type' => 'email',
+            'key' => '',
+        ]);
+    }
+
+    // -- Invalid email format --
+
+    #[Test]
+    public function throwsOnInvalidEmailFormat(): void
+    {
+        $this->expectException(InvalidPixDataException::class);
+
+        $this->strategy->validateAndBuild([
+            'type' => 'email',
+            'key' => 'not-an-email',
+        ]);
+    }
+
+    // -- Type normalization --
+
+    #[Test]
+    public function acceptsUppercaseType(): void
+    {
+        $result = $this->strategy->validateAndBuild([
+            'type' => 'EMAIL',
+            'key' => 'someone@email.com',
+        ]);
+
+        $this->assertInstanceOf(PixWithdrawData::class, $result);
+    }
+
+    // -- Generic interface contract --
+
+    #[Test]
+    public function returnTypeImplementsWithdrawMethodData(): void
+    {
+        $result = $this->strategy->validateAndBuild([
+            'type' => 'email',
+            'key' => 'test@example.com',
+        ]);
+
+        // Ensures the strategy returns a generic type, not PIX-coupled
+        $this->assertInstanceOf(WithdrawMethodData::class, $result);
+    }
+}

--- a/test/Unit/Domain/ValueObject/MoneyTest.php
+++ b/test/Unit/Domain/ValueObject/MoneyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HyperfTest\Unit\Domain\ValueObject;
 
+use App\Domain\Exception\InvalidAmountException;
 use App\Domain\ValueObject\Money;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
@@ -51,7 +52,7 @@ class MoneyTest extends TestCase
     #[Test]
     public function fromFloatThrowsOnNegativeValue(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidAmountException::class);
         $this->expectExceptionMessage('negative');
 
         Money::fromFloat(-10.00);
@@ -60,7 +61,7 @@ class MoneyTest extends TestCase
     #[Test]
     public function fromFloatThrowsOnMoreThanTwoDecimals(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidAmountException::class);
         $this->expectExceptionMessage('2 decimal places');
 
         Money::fromFloat(10.123);
@@ -103,7 +104,7 @@ class MoneyTest extends TestCase
     #[Test]
     public function fromStringThrowsOnNonNumeric(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidAmountException::class);
         $this->expectExceptionMessage('Invalid money format');
 
         Money::fromString('abc');
@@ -112,7 +113,7 @@ class MoneyTest extends TestCase
     #[Test]
     public function fromStringThrowsOnEmptyString(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidAmountException::class);
         $this->expectExceptionMessage('Invalid money format');
 
         Money::fromString('');
@@ -121,7 +122,7 @@ class MoneyTest extends TestCase
     #[Test]
     public function fromStringThrowsOnNegative(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidAmountException::class);
         $this->expectExceptionMessage('Invalid money format');
 
         Money::fromString('-5.00');
@@ -130,7 +131,7 @@ class MoneyTest extends TestCase
     #[Test]
     public function fromStringThrowsOnMoreThanTwoDecimals(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidAmountException::class);
         $this->expectExceptionMessage('Invalid money format');
 
         Money::fromString('10.123');

--- a/test/Unit/Domain/ValueObject/PixKeyTest.php
+++ b/test/Unit/Domain/ValueObject/PixKeyTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace HyperfTest\Unit\Domain\ValueObject;
 
 use App\Domain\Enum\PixKeyType;
+use App\Domain\Exception\InvalidPixDataException;
 use App\Domain\ValueObject\PixKey;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -57,7 +57,7 @@ class PixKeyTest extends TestCase
     #[Test]
     public function createThrowsOnInvalidType(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
         $this->expectExceptionMessage('Invalid PIX key type: phone');
 
         PixKey::create('phone', '+5511999999999');
@@ -66,7 +66,7 @@ class PixKeyTest extends TestCase
     #[Test]
     public function createThrowsOnEmptyType(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
         $this->expectExceptionMessage('Invalid PIX key type');
 
         PixKey::create('', 'someone@email.com');
@@ -77,7 +77,7 @@ class PixKeyTest extends TestCase
     #[Test]
     public function createDelegatesToPixKeyTypeValidation(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
 
         PixKey::create('email', 'not-an-email');
     }
@@ -85,7 +85,7 @@ class PixKeyTest extends TestCase
     #[Test]
     public function createThrowsOnWhitespaceOnlyKey(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidPixDataException::class);
         $this->expectExceptionMessage('PIX key cannot be empty');
 
         PixKey::create('email', '   ');

--- a/test/Unit/Domain/ValueObject/UuidTest.php
+++ b/test/Unit/Domain/ValueObject/UuidTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace HyperfTest\Unit\Domain\ValueObject;
 
+use App\Domain\Exception\InvalidUuidException;
 use App\Domain\ValueObject\Uuid;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +37,7 @@ class UuidTest extends TestCase
     #[Test]
     public function fromStringThrowsOnInvalidFormat(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUuidException::class);
         $this->expectExceptionMessage('Invalid UUID format');
 
         Uuid::fromString('not-a-uuid');
@@ -46,7 +46,7 @@ class UuidTest extends TestCase
     #[Test]
     public function fromStringThrowsOnEmptyString(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUuidException::class);
 
         Uuid::fromString('');
     }


### PR DESCRIPTION
Closes #26 

This pull request refactors domain exception handling to use custom business exceptions instead of generic `InvalidArgumentException`, and introduces new abstractions for withdrawal strategies, specifically for PIX withdrawals. The changes improve error reporting, clarity, and extensibility in the domain layer, and update related tests to expect the new custom exceptions.

### Exception Handling Improvements

* Replaced all usages of `InvalidArgumentException` with custom exceptions: `InvalidAmountException`, `InvalidPixDataException`, and `InvalidUuidException` throughout domain entities and value objects such as `Account`, `Money`, `PixKey`, and `Uuid`. This provides more specific error codes and messages for domain errors. [[1]](diffhunk://#diff-cfec5c9ae02a98a3cea030460c89a8f6ddb8c452b87b82bb95d97f211fc831f8R8-L10) [[2]](diffhunk://#diff-cfec5c9ae02a98a3cea030460c89a8f6ddb8c452b87b82bb95d97f211fc831f8L29-R29) [[3]](diffhunk://#diff-090af1903c0879313c84d8314b81c56975ec3f3dbdd6998021899f9c2625c0a1L7-R7) [[4]](diffhunk://#diff-090af1903c0879313c84d8314b81c56975ec3f3dbdd6998021899f9c2625c0a1L16-R16) [[5]](diffhunk://#diff-090af1903c0879313c84d8314b81c56975ec3f3dbdd6998021899f9c2625c0a1L27-R27) [[6]](diffhunk://#diff-4ea8416d2ec0f0709dbb4d4901a9b389a5e25d645e4f2190363d179c83847fa7R7) [[7]](diffhunk://#diff-4ea8416d2ec0f0709dbb4d4901a9b389a5e25d645e4f2190363d179c83847fa7L23-R28) [[8]](diffhunk://#diff-4ea8416d2ec0f0709dbb4d4901a9b389a5e25d645e4f2190363d179c83847fa7L36-R37) [[9]](diffhunk://#diff-09484a63f442b2950cb0cf51b874c5bad8a4db964ec78734a4f724fcef5e7e96L8-R8) [[10]](diffhunk://#diff-09484a63f442b2950cb0cf51b874c5bad8a4db964ec78734a4f724fcef5e7e96L23-R23) [[11]](diffhunk://#diff-18cf519d4c4ff6673ceb20bf290aa21a19e22f697ada40ee58d7df534ce75882L7-R7) [[12]](diffhunk://#diff-18cf519d4c4ff6673ceb20bf290aa21a19e22f697ada40ee58d7df534ce75882L25-R25)
* Added new exception classes: `InvalidAmountException`, `InvalidPixDataException`, and `InvalidUuidException`, each providing domain-specific error codes and messages. [[1]](diffhunk://#diff-23c31400c17f49223fc0c04ec5dcf5ad0f84a78997fdb1430ed70d14e26b14d7R1-R38) [[2]](diffhunk://#diff-c4c53ef34a4c1d0302292075a64b95366d9923c7c870e67a1a631016bc354307R1-R33) [[3]](diffhunk://#diff-42b99fe742f9c9ef50c30c6d7f2eac02990189718574580a303b02cd1a79e914R1-R23)

### Withdrawal Strategy Abstractions

* Introduced strategy interfaces and implementations for withdrawal methods: `WithdrawMethodStrategyInterface`, `WithdrawMethodData`, `PixWithdrawStrategy`, and `PixWithdrawData`, allowing for extensible and type-safe handling of different withdrawal mechanisms. [[1]](diffhunk://#diff-918611924ad096d994e85dc98d14e3864d8127fe7c6be4f42d443fd38ae5bce7R1-R19) [[2]](diffhunk://#diff-48fadc599f8d90ac8905086a5d6cf99eb4330dc159e1c26a83c342d14ef60da6R1-R17) [[3]](diffhunk://#diff-c4962d81f5d916d004c42c76184f525b706b4faa1d50ab566165f2f2fe7a2071R1-R9) [[4]](diffhunk://#diff-0efb44746afe71ba487839d6c6c70d58f41d0bb7bbd8849b1c72ff623a99a850R1-R10)

### Test Suite Updates

* Updated unit tests to expect the new custom exceptions instead of `InvalidArgumentException`, ensuring test coverage is aligned with the new domain error handling. [[1]](diffhunk://#diff-35094c188a58e185fd30db0e22cf9e7008f46e9356bd6c41b51fcda529923b6dR9-L11) [[2]](diffhunk://#diff-35094c188a58e185fd30db0e22cf9e7008f46e9356bd6c41b51fcda529923b6dL106-R106) [[3]](diffhunk://#diff-0dcc09cd870b62d3497a4afff0f62c97f55659d3727509e92671c5ec255ce596L8-R8) [[4]](diffhunk://#diff-0dcc09cd870b62d3497a4afff0f62c97f55659d3727509e92671c5ec255ce596L30-R30) [[5]](diffhunk://#diff-0dcc09cd870b62d3497a4afff0f62c97f55659d3727509e92671c5ec255ce596L39-R39) [[6]](diffhunk://#diff-0dcc09cd870b62d3497a4afff0f62c97f55659d3727509e92671c5ec255ce596L48-R48) [[7]](diffhunk://#diff-0dcc09cd870b62d3497a4afff0f62c97f55659d3727509e92671c5ec255ce596L57-R57) [[8]](diffhunk://#diff-6ead6cad4f726462c6aea769b49223bd9a03ff91e3d0878a70b0f891a2631545R7) [[9]](diffhunk://#diff-6ead6cad4f726462c6aea769b49223bd9a03ff91e3d0878a70b0f891a2631545L54-R55) [[10]](diffhunk://#diff-6ead6cad4f726462c6aea769b49223bd9a03ff91e3d0878a70b0f891a2631545L63-R64)
* Added comprehensive tests for the new PIX withdrawal strategy, covering valid and invalid cases, type normalization, and interface contracts.

These changes collectively strengthen the domain model's robustness and pave the way for future extensibility in withdrawal methods and error handling.