### PR TITLE
Create Mappers

### DIFF
--- a/app/Infrastructure/Persistence/Mapper/AccountMapper.php
+++ b/app/Infrastructure/Persistence/Mapper/AccountMapper.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Mapper;
+
+use App\Domain\Entity\Account;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\Uuid;
+use App\Infrastructure\Persistence\Model\AccountModel;
+
+class AccountMapper
+{
+    public function toDomain(AccountModel $model): Account
+    {
+        return Account::create(
+            Uuid::fromString($model->id),
+            $model->name,
+            Money::fromString($model->balance),
+        );
+    }
+
+    public function toModel(Account $entity): array
+    {
+        return [
+            'id' => $entity->id()->value(),
+            'name' => $entity->name(),
+            'balance' => $entity->balance()->toDecimal(),
+        ];
+    }
+}

--- a/app/Infrastructure/Persistence/Mapper/WithdrawMapper.php
+++ b/app/Infrastructure/Persistence/Mapper/WithdrawMapper.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Mapper;
+
+use App\Domain\Entity\AccountWithdraw;
+use App\Domain\Entity\AccountWithdrawPix;
+use App\Domain\Enum\WithdrawMethod;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\PixKey;
+use App\Domain\ValueObject\Uuid;
+use App\Infrastructure\Persistence\Model\AccountWithdrawModel;
+use App\Infrastructure\Persistence\Model\AccountWithdrawPixModel;
+use Carbon\Carbon;
+use DateTimeImmutable;
+
+class WithdrawMapper
+{
+    public function toDomain(AccountWithdrawModel $model): AccountWithdraw
+    {
+        return AccountWithdraw::reconstitute(
+            id: Uuid::fromString($model->id),
+            accountId: Uuid::fromString($model->account_id),
+            method: WithdrawMethod::from($model->method),
+            amount: Money::fromString($model->amount),
+            scheduled: $model->scheduled,
+            scheduledFor: $this->toDateTimeImmutable($model->scheduled_for),
+            done: $model->done,
+            error: $model->error,
+            errorReason: $model->error_reason,
+            createdAt: $this->toDateTimeImmutable($model->created_at) ?? new DateTimeImmutable(),
+        );
+    }
+
+    public function pixToDomain(AccountWithdrawPixModel $model): AccountWithdrawPix
+    {
+        return AccountWithdrawPix::create(
+            Uuid::fromString($model->account_withdraw_id),
+            PixKey::create($model->type, $model->key),
+        );
+    }
+
+    private function toDateTimeImmutable(mixed $value): ?DateTimeImmutable
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof DateTimeImmutable) {
+            return $value;
+        }
+
+        if ($value instanceof Carbon) {
+            return $value->toDateTimeImmutable();
+        }
+
+        return new DateTimeImmutable((string) $value);
+    }
+}

--- a/app/Infrastructure/Persistence/Model/AccountModel.php
+++ b/app/Infrastructure/Persistence/Model/AccountModel.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Model;
 
+use Carbon\Carbon;
+
+/**
+ * @property string $id
+ * @property string $name
+ * @property string $balance
+ * @property null|Carbon $created_at
+ * @property null|Carbon $updated_at
+ */
 class AccountModel extends Model
 {
     public bool $incrementing = false;

--- a/app/Infrastructure/Persistence/Model/AccountWithdrawModel.php
+++ b/app/Infrastructure/Persistence/Model/AccountWithdrawModel.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Model;
 
+use Carbon\Carbon;
 use Hyperf\Database\Model\Relations\BelongsTo;
 use Hyperf\Database\Model\Relations\HasOne;
 
+/**
+ * @property string $id
+ * @property string $account_id
+ * @property string $method
+ * @property string $amount
+ * @property bool $scheduled
+ * @property null|Carbon $scheduled_for
+ * @property bool $done
+ * @property bool $error
+ * @property null|string $error_reason
+ * @property null|Carbon $created_at
+ * @property null|Carbon $updated_at
+ * @property AccountModel $account
+ * @property null|AccountWithdrawPixModel $pix
+ */
 class AccountWithdrawModel extends Model
 {
     public bool $incrementing = false;

--- a/app/Infrastructure/Persistence/Model/AccountWithdrawPixModel.php
+++ b/app/Infrastructure/Persistence/Model/AccountWithdrawPixModel.php
@@ -6,6 +6,12 @@ namespace App\Infrastructure\Persistence\Model;
 
 use Hyperf\Database\Model\Relations\BelongsTo;
 
+/**
+ * @property string $account_withdraw_id
+ * @property string $type
+ * @property string $key
+ * @property AccountWithdrawModel $withdraw
+ */
 class AccountWithdrawPixModel extends Model
 {
     public bool $incrementing = false;

--- a/test/Unit/Infrastructure/Persistence/Mapper/AccountMapperTest.php
+++ b/test/Unit/Infrastructure/Persistence/Mapper/AccountMapperTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Infrastructure\Persistence\Mapper;
+
+use App\Domain\Entity\Account;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\Uuid;
+use App\Infrastructure\Persistence\Mapper\AccountMapper;
+use App\Infrastructure\Persistence\Model\AccountModel;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class AccountMapperTest extends TestCase
+{
+    private AccountMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new AccountMapper();
+    }
+
+    #[Test]
+    public function toDomainHydratesAccountCorrectly(): void
+    {
+        $model = new AccountModel();
+        $model->id = '550e8400-e29b-41d4-a716-446655440000';
+        $model->name = 'John Doe';
+        $model->balance = '1500.50';
+
+        $account = $this->mapper->toDomain($model);
+
+        $this->assertSame('550e8400-e29b-41d4-a716-446655440000', $account->id()->value());
+        $this->assertSame('John Doe', $account->name());
+        $this->assertSame('1500.50', $account->balance()->toDecimal());
+    }
+
+    #[Test]
+    public function toModelExtractsDataCorrectly(): void
+    {
+        $account = Account::create(
+            Uuid::fromString('550e8400-e29b-41d4-a716-446655440000'),
+            'Jane Doe',
+            Money::fromFloat(250.75),
+        );
+
+        $data = $this->mapper->toModel($account);
+
+        $this->assertSame('550e8400-e29b-41d4-a716-446655440000', $data['id']);
+        $this->assertSame('Jane Doe', $data['name']);
+        $this->assertSame('250.75', $data['balance']);
+    }
+
+    #[Test]
+    public function roundTripPreservesData(): void
+    {
+        $original = Account::create(
+            Uuid::fromString('550e8400-e29b-41d4-a716-446655440000'),
+            'Test User',
+            Money::fromFloat(999.99),
+        );
+
+        $data = $this->mapper->toModel($original);
+
+        $model = new AccountModel();
+        $model->id = $data['id'];
+        $model->name = $data['name'];
+        $model->balance = $data['balance'];
+
+        $restored = $this->mapper->toDomain($model);
+
+        $this->assertSame($original->id()->value(), $restored->id()->value());
+        $this->assertSame($original->name(), $restored->name());
+        $this->assertSame($original->balance()->toDecimal(), $restored->balance()->toDecimal());
+    }
+}

--- a/test/Unit/Infrastructure/Persistence/Mapper/WithdrawMapperTest.php
+++ b/test/Unit/Infrastructure/Persistence/Mapper/WithdrawMapperTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Infrastructure\Persistence\Mapper;
+
+use App\Domain\Enum\WithdrawMethod;
+use App\Infrastructure\Persistence\Mapper\WithdrawMapper;
+use App\Infrastructure\Persistence\Model\AccountWithdrawModel;
+use App\Infrastructure\Persistence\Model\AccountWithdrawPixModel;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class WithdrawMapperTest extends TestCase
+{
+    private WithdrawMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new WithdrawMapper();
+    }
+
+    // -- toDomain --
+
+    #[Test]
+    public function toDomainHydratesImmediateWithdrawCorrectly(): void
+    {
+        $model = new AccountWithdrawModel();
+        $model->id = '550e8400-e29b-41d4-a716-446655440001';
+        $model->account_id = '550e8400-e29b-41d4-a716-446655440000';
+        $model->method = 'pix';
+        $model->amount = '150.75';
+        $model->scheduled = false;
+        $model->scheduled_for = null;
+        $model->done = true;
+        $model->error = false;
+        $model->error_reason = null;
+        $model->created_at = '2026-03-05 10:30:00';
+
+        $withdraw = $this->mapper->toDomain($model);
+
+        $this->assertSame('550e8400-e29b-41d4-a716-446655440001', $withdraw->id()->value());
+        $this->assertSame('550e8400-e29b-41d4-a716-446655440000', $withdraw->accountId()->value());
+        $this->assertSame(WithdrawMethod::PIX, $withdraw->method());
+        $this->assertSame('150.75', $withdraw->amount()->toDecimal());
+        $this->assertFalse($withdraw->isScheduled());
+        $this->assertNull($withdraw->scheduledFor());
+        $this->assertTrue($withdraw->isDone());
+        $this->assertFalse($withdraw->hasError());
+        $this->assertNull($withdraw->errorReason());
+        $this->assertSame('2026-03-05 10:30:00', $withdraw->createdAt()->format('Y-m-d H:i:s'));
+    }
+
+    #[Test]
+    public function toDomainHydratesScheduledWithdrawCorrectly(): void
+    {
+        $model = new AccountWithdrawModel();
+        $model->id = '550e8400-e29b-41d4-a716-446655440002';
+        $model->account_id = '550e8400-e29b-41d4-a716-446655440000';
+        $model->method = 'pix';
+        $model->amount = '500.00';
+        $model->scheduled = true;
+        $model->scheduled_for = '2026-06-15 10:00:00';
+        $model->done = false;
+        $model->error = false;
+        $model->error_reason = null;
+        $model->created_at = '2026-03-05 10:30:00';
+
+        $withdraw = $this->mapper->toDomain($model);
+
+        $this->assertTrue($withdraw->isScheduled());
+        $this->assertNotNull($withdraw->scheduledFor());
+        $this->assertSame('2026-06-15 10:00:00', $withdraw->scheduledFor()->format('Y-m-d H:i:s'));
+        $this->assertFalse($withdraw->isDone());
+    }
+
+    #[Test]
+    public function toDomainHydratesFailedWithdrawCorrectly(): void
+    {
+        $model = new AccountWithdrawModel();
+        $model->id = '550e8400-e29b-41d4-a716-446655440003';
+        $model->account_id = '550e8400-e29b-41d4-a716-446655440000';
+        $model->method = 'pix';
+        $model->amount = '200.00';
+        $model->scheduled = true;
+        $model->scheduled_for = '2026-03-01 10:00:00';
+        $model->done = false;
+        $model->error = true;
+        $model->error_reason = 'Insufficient balance';
+        $model->created_at = '2026-02-28 10:00:00';
+
+        $withdraw = $this->mapper->toDomain($model);
+
+        $this->assertTrue($withdraw->hasError());
+        $this->assertSame('Insufficient balance', $withdraw->errorReason());
+        $this->assertFalse($withdraw->isDone());
+    }
+
+    // -- pixToDomain --
+
+    #[Test]
+    public function pixToDomainHydratesCorrectly(): void
+    {
+        $model = new AccountWithdrawPixModel();
+        $model->account_withdraw_id = '550e8400-e29b-41d4-a716-446655440001';
+        $model->type = 'email';
+        $model->key = 'fulano@email.com';
+
+        $pix = $this->mapper->pixToDomain($model);
+
+        $this->assertSame('550e8400-e29b-41d4-a716-446655440001', $pix->accountWithdrawId()->value());
+        $this->assertSame('email', $pix->pixKey()->type()->value);
+        $this->assertSame('fulano@email.com', $pix->pixKey()->key());
+    }
+}


### PR DESCRIPTION
Closes #35 

This pull request introduces new mapper classes for handling conversion between persistence models and domain entities for accounts and withdrawals, along with comprehensive unit tests to ensure correct behavior. It also adds detailed property annotations to the persistence models for improved clarity and type safety.

### Mapper classes and conversion logic

* Added `AccountMapper` and `WithdrawMapper` classes to convert between domain entities (`Account`, `AccountWithdraw`, `AccountWithdrawPix`) and their corresponding persistence models, including handling of value objects and enums. (`[[1]](diffhunk://#diff-7205c525dded3568cb8d3fbed4baeb83dcb6f2cc47e4844fb9b5a75c62e343c6R1-R31)`, `[[2]](diffhunk://#diff-151b92e7c07c871d5f446b47343b96d140d5f427fdd3c622486741d51d272c1eR1-R60)`)
* Implemented a robust date/time conversion method in `WithdrawMapper` to handle multiple input types for date fields. (`[app/Infrastructure/Persistence/Mapper/WithdrawMapper.phpR1-R60](diffhunk://#diff-151b92e7c07c871d5f446b47343b96d140d5f427fdd3c622486741d51d272c1eR1-R60)`)

### Model annotations

* Added PHPDoc property annotations to `AccountModel`, `AccountWithdrawModel`, and `AccountWithdrawPixModel` to specify expected properties and types, improving IDE support and code maintainability. (`[[1]](diffhunk://#diff-4cf297847836bb31bca37b3b0c20f3602ba06c8777f8ec53df334239338e6b50R7-R15)`, `[[2]](diffhunk://#diff-fcd1ab3f8ac69d0039c1348f56623a32709fffd12b9c8c6d590a874fccacba72R7-R25)`, `[[3]](diffhunk://#diff-8dab24a0d18c340836cab6b3ae32e4c9e0d4dfb1a5d3eb5946f15c33bfec679aR9-R14)`)

### Unit tests

* Added `AccountMapperTest` and `WithdrawMapperTest` to verify correct hydration and extraction of domain entities and models, including round-trip consistency and handling of different withdrawal scenarios (immediate, scheduled, failed, and Pix withdrawals). (`[[1]](diffhunk://#diff-a1e21e6a9cf8c65c4b4f6d5ceae360a6161db615bc7000b32cb36122a108fe71R1-R80)`, `[[2]](diffhunk://#diff-4e41cb592b98f6ae28e52f1ae77cb7e2b7ed6540e727540e115f39f2d8c7208dR1-R118)`)