### PR TITLE
Create SymfonyMailerService

### DIFF
--- a/app/Infrastructure/Mail/SymfonyMailerService.php
+++ b/app/Infrastructure/Mail/SymfonyMailerService.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Mail;
+
+use App\Domain\Entity\AccountWithdraw;
+use App\Domain\Entity\AccountWithdrawPix;
+use App\Infrastructure\Mail\Template\WithdrawCompletedEmailTemplate;
+use Symfony\Component\Mailer\MailerInterface;
+
+class SymfonyMailerService
+{
+    public function __construct(
+        private readonly MailerInterface $mailer,
+        private readonly string $from,
+        private readonly WithdrawCompletedEmailTemplate $withdrawCompletedTemplate = new WithdrawCompletedEmailTemplate(),
+    ) {
+    }
+
+    public function sendWithdrawCompleted(
+        AccountWithdraw $withdraw,
+        AccountWithdrawPix $pix,
+    ): void {
+        $email = $this->withdrawCompletedTemplate->build($this->from, $withdraw, $pix);
+
+        $this->mailer->send($email);
+    }
+}

--- a/app/Infrastructure/Mail/SymfonyMailerServiceFactory.php
+++ b/app/Infrastructure/Mail/SymfonyMailerServiceFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Mail;
+
+use Hyperf\Contract\ConfigInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport;
+
+class SymfonyMailerServiceFactory
+{
+    public function __invoke(ContainerInterface $container): SymfonyMailerService
+    {
+        $config = $container->get(ConfigInterface::class);
+
+        $host = $config->get('mail.host', 'mailhog');
+        $port = (int) $config->get('mail.port', 1025);
+        $from = $config->get('mail.from', 'no-reply@jsr-pix-withdrawal.local');
+
+        $dsn = sprintf('smtp://%s:%d', $host, $port);
+        $transport = Transport::fromDsn($dsn);
+        $mailer = new Mailer($transport);
+
+        return new SymfonyMailerService($mailer, $from);
+    }
+}

--- a/app/Infrastructure/Mail/Template/WithdrawCompletedEmailTemplate.php
+++ b/app/Infrastructure/Mail/Template/WithdrawCompletedEmailTemplate.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Mail\Template;
+
+use App\Domain\Entity\AccountWithdraw;
+use App\Domain\Entity\AccountWithdrawPix;
+use RuntimeException;
+use Symfony\Component\Mime\Email;
+
+class WithdrawCompletedEmailTemplate
+{
+    private const TEMPLATE_PATH = __DIR__ . '/html/withdraw-completed.html';
+
+    public function build(string $from, AccountWithdraw $withdraw, AccountWithdrawPix $pix): Email
+    {
+        $dateTime = $withdraw->createdAt()->format('Y-m-d H:i:s');
+        $amount = $withdraw->amount()->toDecimal();
+        $pixType = $pix->pixKey()->type()->value;
+        $pixKey = $pix->pixKey()->key();
+
+        $html = $this->loadTemplate([
+            '{{ dateTime }}' => $dateTime,
+            '{{ amount }}' => $amount,
+            '{{ pixType }}' => $pixType,
+            '{{ pixKey }}' => $pixKey,
+        ]);
+
+        return (new Email())
+            ->from($from)
+            ->to($pixKey)
+            ->subject('PIX Withdrawal Completed')
+            ->html($html);
+    }
+
+    /**
+     * @param array<string, string> $placeholders
+     */
+    private function loadTemplate(array $placeholders): string
+    {
+        $path = self::TEMPLATE_PATH;
+
+        if (! file_exists($path)) {
+            throw new RuntimeException("Email template not found: {$path}");
+        }
+
+        $html = file_get_contents($path);
+
+        return str_replace(array_keys($placeholders), array_values($placeholders), $html);
+    }
+}

--- a/app/Infrastructure/Mail/Template/html/withdraw-completed.html
+++ b/app/Infrastructure/Mail/Template/html/withdraw-completed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>PIX Withdrawal Completed</title></head>
+<body style="font-family: Arial, sans-serif; padding: 20px;">
+    <h1 style="color: #2e7d32;">PIX Withdrawal Completed</h1>
+    <table style="border-collapse: collapse; width: 100%; max-width: 500px;">
+        <tr>
+            <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Date/Time</td>
+            <td style="padding: 8px; border: 1px solid #ddd;">{{ dateTime }}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Amount</td>
+            <td style="padding: 8px; border: 1px solid #ddd;">R$ {{ amount }}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">PIX Type</td>
+            <td style="padding: 8px; border: 1px solid #ddd;">{{ pixType }}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">PIX Key</td>
+            <td style="padding: 8px; border: 1px solid #ddd;">{{ pixKey }}</td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/config/autoload/dependencies.php
+++ b/config/autoload/dependencies.php
@@ -6,6 +6,8 @@ use App\Domain\Port\AccountRepositoryInterface;
 use App\Domain\Port\EventDispatcherInterface;
 use App\Domain\Port\WithdrawRepositoryInterface;
 use App\Infrastructure\Event\HyperfEventDispatcherAdapter;
+use App\Infrastructure\Mail\SymfonyMailerService;
+use App\Infrastructure\Mail\SymfonyMailerServiceFactory;
 use App\Infrastructure\Persistence\Repository\EloquentAccountRepository;
 use App\Infrastructure\Persistence\Repository\EloquentWithdrawRepository;
 
@@ -13,4 +15,5 @@ return [
     AccountRepositoryInterface::class => EloquentAccountRepository::class,
     WithdrawRepositoryInterface::class => EloquentWithdrawRepository::class,
     EventDispatcherInterface::class => HyperfEventDispatcherAdapter::class,
+    SymfonyMailerService::class => SymfonyMailerServiceFactory::class,
 ];

--- a/config/autoload/mail.php
+++ b/config/autoload/mail.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use function Hyperf\Support\env;
+
+return [
+    'host' => env('MAIL_HOST', 'mailhog'),
+    'port' => (int) env('MAIL_PORT', 1025),
+    'from' => env('MAIL_FROM_ADDRESS', 'no-reply@jsr-pix-withdrawal.local'),
+];

--- a/config/config.php
+++ b/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 use Hyperf\Contract\StdoutLoggerInterface;
 use Psr\Log\LogLevel;
 
@@ -11,15 +12,33 @@ return [
     'app_env' => env('APP_ENV', 'dev'),
     'scan_cacheable' => env('SCAN_CACHEABLE', false),
     StdoutLoggerInterface::class => [
-        'log_level' => [
-            LogLevel::ALERT,
-            LogLevel::CRITICAL,
-            LogLevel::DEBUG,
-            LogLevel::EMERGENCY,
-            LogLevel::ERROR,
-            LogLevel::INFO,
-            LogLevel::NOTICE,
-            LogLevel::WARNING,
-        ],
+        'log_level' => match (env('APP_ENV')) {
+            'production' => [
+                LogLevel::ALERT,
+                LogLevel::CRITICAL,
+                LogLevel::EMERGENCY,
+                LogLevel::ERROR,
+                LogLevel::WARNING,
+                LogLevel::INFO,
+            ],
+            'testing' => [
+                LogLevel::ALERT,
+                LogLevel::CRITICAL,
+                LogLevel::EMERGENCY,
+                LogLevel::ERROR,
+                LogLevel::WARNING,
+                LogLevel::INFO,
+            ],
+            default => [
+                LogLevel::ALERT,
+                LogLevel::CRITICAL,
+                LogLevel::DEBUG,
+                LogLevel::EMERGENCY,
+                LogLevel::ERROR,
+                LogLevel::INFO,
+                LogLevel::NOTICE,
+                LogLevel::WARNING,
+            ],
+        },
     ],
 ];

--- a/test/Unit/Infrastructure/Mail/SymfonyMailerServiceTest.php
+++ b/test/Unit/Infrastructure/Mail/SymfonyMailerServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Infrastructure\Mail;
+
+use App\Domain\Entity\AccountWithdraw;
+use App\Domain\Entity\AccountWithdrawPix;
+use App\Domain\Enum\WithdrawMethod;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\PixKey;
+use App\Domain\ValueObject\Uuid;
+use App\Infrastructure\Mail\SymfonyMailerService;
+use App\Infrastructure\Mail\Template\WithdrawCompletedEmailTemplate;
+use HyperfTest\Support\UsesMockery;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+
+/**
+ * @internal
+ */
+class SymfonyMailerServiceTest extends TestCase
+{
+    use UsesMockery;
+
+    private MailerInterface $mailer;
+
+    private WithdrawCompletedEmailTemplate $template;
+
+    private SymfonyMailerService $service;
+
+    protected function setUp(): void
+    {
+        $this->mailer = Mockery::mock(MailerInterface::class);
+        $this->template = Mockery::mock(WithdrawCompletedEmailTemplate::class);
+        $this->service = new SymfonyMailerService($this->mailer, 'no-reply@test.local', $this->template);
+    }
+
+    #[Test]
+    public function sendWithdrawCompletedBuildsEmailFromTemplateAndSends(): void
+    {
+        $withdraw = $this->createWithdraw('150.75');
+        $pix = $this->createPix('user@example.com');
+        $expectedEmail = new Email();
+
+        $this->template->shouldReceive('build')
+            ->once()
+            ->with('no-reply@test.local', $withdraw, $pix)
+            ->andReturn($expectedEmail);
+
+        $this->mailer->shouldReceive('send')
+            ->once()
+            ->with($expectedEmail);
+
+        $this->service->sendWithdrawCompleted($withdraw, $pix);
+    }
+
+    private function createWithdraw(string $amount): AccountWithdraw
+    {
+        return AccountWithdraw::createImmediate(
+            Uuid::generate(),
+            Uuid::generate(),
+            WithdrawMethod::PIX,
+            Money::fromString($amount),
+        );
+    }
+
+    private function createPix(string $email): AccountWithdrawPix
+    {
+        return AccountWithdrawPix::create(
+            Uuid::generate(),
+            PixKey::create('email', $email),
+        );
+    }
+}

--- a/test/Unit/Infrastructure/Mail/Template/WithdrawCompletedEmailTemplateTest.php
+++ b/test/Unit/Infrastructure/Mail/Template/WithdrawCompletedEmailTemplateTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Infrastructure\Mail\Template;
+
+use App\Domain\Entity\AccountWithdraw;
+use App\Domain\Entity\AccountWithdrawPix;
+use App\Domain\Enum\WithdrawMethod;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\PixKey;
+use App\Domain\ValueObject\Uuid;
+use App\Infrastructure\Mail\Template\WithdrawCompletedEmailTemplate;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class WithdrawCompletedEmailTemplateTest extends TestCase
+{
+    private WithdrawCompletedEmailTemplate $template;
+
+    protected function setUp(): void
+    {
+        $this->template = new WithdrawCompletedEmailTemplate();
+    }
+
+    #[Test]
+    public function buildSetsFromAddress(): void
+    {
+        $email = $this->template->build(
+            'no-reply@test.local',
+            $this->createWithdraw('100.00'),
+            $this->createPix('user@example.com'),
+        );
+
+        $fromAddresses = $email->getFrom();
+        $this->assertCount(1, $fromAddresses);
+        $this->assertSame('no-reply@test.local', $fromAddresses[0]->getAddress());
+    }
+
+    #[Test]
+    public function buildSetsToAsPixKey(): void
+    {
+        $email = $this->template->build(
+            'no-reply@test.local',
+            $this->createWithdraw('100.00'),
+            $this->createPix('recipient@bank.com'),
+        );
+
+        $toAddresses = $email->getTo();
+        $this->assertCount(1, $toAddresses);
+        $this->assertSame('recipient@bank.com', $toAddresses[0]->getAddress());
+    }
+
+    #[Test]
+    public function buildSetsCorrectSubject(): void
+    {
+        $email = $this->template->build(
+            'no-reply@test.local',
+            $this->createWithdraw('100.00'),
+            $this->createPix('user@example.com'),
+        );
+
+        $this->assertSame('PIX Withdrawal Completed', $email->getSubject());
+    }
+
+    #[Test]
+    public function buildHtmlContainsDateTime(): void
+    {
+        $withdraw = $this->createWithdraw('250.00');
+        $expectedDate = $withdraw->createdAt()->format('Y-m-d H:i:s');
+
+        $email = $this->template->build(
+            'no-reply@test.local',
+            $withdraw,
+            $this->createPix('user@example.com'),
+        );
+
+        $this->assertStringContainsString($expectedDate, $email->getHtmlBody());
+    }
+
+    #[Test]
+    public function buildHtmlContainsAmount(): void
+    {
+        $email = $this->template->build(
+            'no-reply@test.local',
+            $this->createWithdraw('1500.99'),
+            $this->createPix('user@example.com'),
+        );
+
+        $this->assertStringContainsString('R$ 1500.99', $email->getHtmlBody());
+    }
+
+    #[Test]
+    public function buildHtmlContainsPixType(): void
+    {
+        $email = $this->template->build(
+            'no-reply@test.local',
+            $this->createWithdraw('100.00'),
+            $this->createPix('user@example.com'),
+        );
+
+        $this->assertStringContainsString('email', $email->getHtmlBody());
+    }
+
+    #[Test]
+    public function buildHtmlContainsPixKey(): void
+    {
+        $email = $this->template->build(
+            'no-reply@test.local',
+            $this->createWithdraw('100.00'),
+            $this->createPix('recipient@bank.com'),
+        );
+
+        $this->assertStringContainsString('recipient@bank.com', $email->getHtmlBody());
+    }
+
+    private function createWithdraw(string $amount): AccountWithdraw
+    {
+        return AccountWithdraw::createImmediate(
+            Uuid::generate(),
+            Uuid::generate(),
+            WithdrawMethod::PIX,
+            Money::fromString($amount),
+        );
+    }
+
+    private function createPix(string $email): AccountWithdrawPix
+    {
+        return AccountWithdrawPix::create(
+            Uuid::generate(),
+            PixKey::create('email', $email),
+        );
+    }
+}


### PR DESCRIPTION
Closes #40 

This pull request introduces a new email notification system for completed PIX withdrawals. It adds a service for sending emails using Symfony Mailer, a factory for service instantiation, a template for withdrawal completion emails, and configuration for mail settings. Comprehensive unit tests are provided to verify the email sending logic and template rendering.

Email Notification System for PIX Withdrawals:

* Added `SymfonyMailerService` for sending withdrawal completion emails, using a dedicated HTML template and Symfony Mailer.
* Implemented `WithdrawCompletedEmailTemplate` to generate HTML emails with withdrawal details, including date/time, amount, PIX type, and PIX key. [[1]](diffhunk://#diff-c38b100ec166f054a39ab64579c947710452beda4fb4904befa2bced0b64b8baR1-R52) [[2]](diffhunk://#diff-9aff97403ef09cfbd6730ae2f9ab9e315ecb66110879d0d3b63dd59cfac538daR1-R25)

Service Instantiation and Configuration:

* Created `SymfonyMailerServiceFactory` to instantiate the mailer service with configuration values for host, port, and sender address.
* Registered the mailer service and factory in the dependency injection container and added mail configuration file for environment-based settings. [[1]](diffhunk://#diff-981cad0c33f29835ffbedec79d499949caee903fd2939649d8dae2c241daa872R9-R18) [[2]](diffhunk://#diff-1e7a83f984b43264570f0116f52207230b05d77b20d70591a7365c68bfbf031dR1-R11)

Testing:

* Added unit tests for `SymfonyMailerService` and `WithdrawCompletedEmailTemplate` to ensure correct email construction and sending behavior. [[1]](diffhunk://#diff-56923096828a61df10cd71e47392509eef48a16637a3acd0554d8f38f1e91617R1-R78) [[2]](diffhunk://#diff-67fab2e7267c59ec2cc0fe18ceabac702957eeabb3ae27eae0732518d868d156R1-R137)