### PR TITLE
Create CreateWithdrawRequest

### DIFF
--- a/app/Exception/Handler/ValidationExceptionHandler.php
+++ b/app/Exception/Handler/ValidationExceptionHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Handler;
+
+use Hyperf\ExceptionHandler\ExceptionHandler;
+use Hyperf\HttpMessage\Stream\SwooleStream;
+use Hyperf\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class ValidationExceptionHandler extends ExceptionHandler
+{
+    public function handle(Throwable $throwable, ResponseInterface $response): ResponseInterface
+    {
+        $this->stopPropagation();
+
+        assert($throwable instanceof ValidationException);
+
+        $body = json_encode([
+            'code' => 'VALIDATION_ERROR',
+            'message' => $throwable->getMessage(),
+            'details' => $throwable->validator->errors()->getMessages(),
+        ]);
+
+        return $response
+            ->withStatus($throwable->status)
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(new SwooleStream($body));
+    }
+
+    public function isValid(Throwable $throwable): bool
+    {
+        return $throwable instanceof ValidationException;
+    }
+}

--- a/app/Request/CreateWithdrawRequest.php
+++ b/app/Request/CreateWithdrawRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Request;
+
+use Hyperf\Validation\Request\FormRequest;
+
+class CreateWithdrawRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'method' => ['required', 'string'],
+            'pix.type' => ['required', 'string', 'in:email'],
+            'pix.key' => ['required', 'email'],
+            'amount' => ['required', 'numeric', 'min:0.01'],
+            'schedule' => ['nullable', 'date_format:Y-m-d H:i:s'],
+        ];
+    }
+}

--- a/config/autoload/exceptions.php
+++ b/config/autoload/exceptions.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 use App\Exception\Handler\AppExceptionHandler;
 use App\Exception\Handler\BusinessExceptionHandler;
+use App\Exception\Handler\ValidationExceptionHandler;
 use Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler;
 
 return [
     'handler' => [
         'http' => [
+            ValidationExceptionHandler::class,
             BusinessExceptionHandler::class,
             HttpExceptionHandler::class,
             AppExceptionHandler::class,

--- a/config/autoload/middlewares.php
+++ b/config/autoload/middlewares.php
@@ -1,7 +1,11 @@
 <?php
 
 declare(strict_types=1);
+
+use Hyperf\Validation\Middleware\ValidationMiddleware;
+
 return [
     'http' => [
+        ValidationMiddleware::class,
     ],
 ];

--- a/test/Unit/Exception/Handler/ValidationExceptionHandlerTest.php
+++ b/test/Unit/Exception/Handler/ValidationExceptionHandlerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Exception\Handler;
+
+use App\Exception\Handler\ValidationExceptionHandler;
+use Hyperf\Contract\MessageBag;
+use Hyperf\Contract\ValidatorInterface;
+use Hyperf\HttpMessage\Base\Response;
+use Hyperf\Validation\ValidationException;
+use HyperfTest\Support\UsesMockery;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+class ValidationExceptionHandlerTest extends TestCase
+{
+    use UsesMockery;
+
+    private ValidationExceptionHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->handler = new ValidationExceptionHandler();
+    }
+
+    // -- isValid --
+
+    #[Test]
+    public function isValidReturnsTrueForValidationException(): void
+    {
+        $validator = Mockery::mock(ValidatorInterface::class);
+        $exception = new ValidationException($validator);
+
+        $this->assertTrue($this->handler->isValid($exception));
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForOtherExceptions(): void
+    {
+        $this->assertFalse($this->handler->isValid(new RuntimeException('some error')));
+    }
+
+    // -- handle --
+
+    #[Test]
+    public function handleReturns422StatusCode(): void
+    {
+        $exception = $this->createValidationException(['amount' => ['The amount field is required.']]);
+        $response = new Response();
+
+        $result = $this->handler->handle($exception, $response);
+
+        $this->assertSame(422, $result->getStatusCode());
+    }
+
+    #[Test]
+    public function handleReturnsJsonContentType(): void
+    {
+        $exception = $this->createValidationException(['amount' => ['The amount field is required.']]);
+        $response = new Response();
+
+        $result = $this->handler->handle($exception, $response);
+
+        $this->assertSame('application/json', $result->getHeaderLine('Content-Type'));
+    }
+
+    #[Test]
+    public function handleReturnsValidationErrorCode(): void
+    {
+        $exception = $this->createValidationException(['method' => ['The method field is required.']]);
+        $response = new Response();
+
+        $result = $this->handler->handle($exception, $response);
+        $body = json_decode((string) $result->getBody(), true);
+
+        $this->assertSame('VALIDATION_ERROR', $body['code']);
+    }
+
+    #[Test]
+    public function handleReturnsErrorDetails(): void
+    {
+        $errors = [
+            'method' => ['The method field is required.'],
+            'amount' => ['The amount must be at least 0.01.'],
+        ];
+        $exception = $this->createValidationException($errors);
+        $response = new Response();
+
+        $result = $this->handler->handle($exception, $response);
+        $body = json_decode((string) $result->getBody(), true);
+
+        $this->assertSame($errors, $body['details']);
+    }
+
+    #[Test]
+    public function handleReturnsExceptionMessage(): void
+    {
+        $exception = $this->createValidationException(['pix.key' => ['The pix.key must be a valid email.']]);
+        $response = new Response();
+
+        $result = $this->handler->handle($exception, $response);
+        $body = json_decode((string) $result->getBody(), true);
+
+        $this->assertSame('The given data was invalid.', $body['message']);
+    }
+
+    private function createValidationException(array $errorMessages): ValidationException
+    {
+        $messageBag = Mockery::mock(MessageBag::class);
+        $messageBag->shouldReceive('getMessages')->andReturn($errorMessages);
+
+        /** @var MockInterface|ValidatorInterface $validator */
+        $validator = Mockery::mock(ValidatorInterface::class);
+        $validator->shouldReceive('errors')->andReturn($messageBag);
+
+        return new ValidationException($validator);
+    }
+}

--- a/test/Unit/Request/CreateWithdrawRequestTest.php
+++ b/test/Unit/Request/CreateWithdrawRequestTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Request;
+
+use App\Request\CreateWithdrawRequest;
+use Hyperf\Contract\TranslatorInterface;
+use Hyperf\Contract\ValidatorInterface;
+use Hyperf\Validation\ValidatorFactory;
+use HyperfTest\Support\UsesMockery;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @internal
+ */
+class CreateWithdrawRequestTest extends TestCase
+{
+    use UsesMockery;
+
+    private ValidatorFactory $validatorFactory;
+
+    private CreateWithdrawRequest $request;
+
+    protected function setUp(): void
+    {
+        $translator = Mockery::mock(TranslatorInterface::class);
+        $translator->shouldReceive('get')->andReturnUsing(fn (string $key) => $key);
+        $translator->shouldReceive('trans')->andReturnUsing(fn (string $key) => $key);
+        $translator->shouldReceive('has')->andReturn(false);
+
+        $this->validatorFactory = new ValidatorFactory($translator);
+        $this->request = new CreateWithdrawRequest(Mockery::mock(ContainerInterface::class));
+    }
+
+    // -- authorize --
+
+    #[Test]
+    public function authorizeReturnsTrue(): void
+    {
+        $this->assertTrue($this->request->authorize());
+    }
+
+    // -- valid payload --
+
+    #[Test]
+    public function validPayloadPassesValidation(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 100.50,
+            'schedule' => null,
+        ]);
+
+        $this->assertFalse($validator->fails());
+    }
+
+    #[Test]
+    public function validPayloadWithSchedulePasses(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 0.01,
+            'schedule' => '2026-03-10 14:30:00',
+        ]);
+
+        $this->assertFalse($validator->fails());
+    }
+
+    #[Test]
+    public function validPayloadWithoutSchedulePasses(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 50.00,
+        ]);
+
+        $this->assertFalse($validator->fails());
+    }
+
+    // -- method field --
+
+    #[Test]
+    public function failsWhenMethodIsMissing(): void
+    {
+        $validator = $this->validate([
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 10.00,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('method', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function failsWhenMethodIsNotString(): void
+    {
+        $validator = $this->validate([
+            'method' => 123,
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 10.00,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('method', $validator->errors()->getMessages());
+    }
+
+    // -- pix.type field --
+
+    #[Test]
+    public function failsWhenPixTypeIsMissing(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['key' => 'user@example.com'],
+            'amount' => 10.00,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('pix.type', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function failsWhenPixTypeIsInvalid(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'cpf', 'key' => 'user@example.com'],
+            'amount' => 10.00,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('pix.type', $validator->errors()->getMessages());
+    }
+
+    // -- pix.key field --
+
+    #[Test]
+    public function failsWhenPixKeyIsMissing(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email'],
+            'amount' => 10.00,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('pix.key', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function failsWhenPixKeyIsNotValidEmail(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'not-an-email'],
+            'amount' => 10.00,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('pix.key', $validator->errors()->getMessages());
+    }
+
+    // -- amount field --
+
+    #[Test]
+    public function failsWhenAmountIsMissing(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function failsWhenAmountIsNotNumeric(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 'abc',
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function failsWhenAmountIsZero(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 0,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function failsWhenAmountIsNegative(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => -5.00,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function failsWhenAmountIsBelowMinimum(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 0.001,
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors()->getMessages());
+    }
+
+    // -- schedule field --
+
+    #[Test]
+    public function failsWhenScheduleHasInvalidFormat(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 10.00,
+            'schedule' => '06/03/2026',
+        ]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('schedule', $validator->errors()->getMessages());
+    }
+
+    #[Test]
+    public function passesWhenScheduleIsNull(): void
+    {
+        $validator = $this->validate([
+            'method' => 'pix',
+            'pix' => ['type' => 'email', 'key' => 'user@example.com'],
+            'amount' => 10.00,
+            'schedule' => null,
+        ]);
+
+        $this->assertArrayNotHasKey('schedule', $validator->errors()->getMessages());
+    }
+
+    // -- multiple errors --
+
+    #[Test]
+    public function returnsMultipleFieldErrors(): void
+    {
+        $validator = $this->validate([]);
+
+        $this->assertTrue($validator->fails());
+        $errors = $validator->errors()->getMessages();
+
+        $this->assertArrayHasKey('method', $errors);
+        $this->assertArrayHasKey('pix.type', $errors);
+        $this->assertArrayHasKey('pix.key', $errors);
+        $this->assertArrayHasKey('amount', $errors);
+    }
+
+    private function validate(array $data): ValidatorInterface
+    {
+        return $this->validatorFactory->make($data, $this->request->rules());
+    }
+}


### PR DESCRIPTION
Closes #43 

This pull request introduces robust validation handling for withdrawal requests, including a new validation exception handler, request validation rules, and comprehensive unit tests. It also integrates validation middleware and exception handling into the application lifecycle.

**Validation Handling Improvements**

* Added `ValidationExceptionHandler` to standardize JSON error responses for validation errors, including error codes, messages, and detailed field errors. (`app/Exception/Handler/ValidationExceptionHandler.php`)
* Registered `ValidationExceptionHandler` in the exception handler stack to ensure validation errors are handled consistently. (`config/autoload/exceptions.php`)
* Enabled `ValidationMiddleware` globally to automatically trigger validation for incoming HTTP requests. (`config/autoload/middlewares.php`)

**Request Validation**

* Implemented `CreateWithdrawRequest` with validation rules for withdrawal requests, enforcing required fields, value types, and constraints (e.g., email format, minimum amount, date format). (`app/Request/CreateWithdrawRequest.php`)

**Testing**

* Added unit tests for `ValidationExceptionHandler` to verify proper error responses and handler logic. (`test/Unit/Exception/Handler/ValidationExceptionHandlerTest.php`)
* Added unit tests for `CreateWithdrawRequest` to validate all rules and edge cases, ensuring correct behavior for valid and invalid payloads. (`test/Unit/Request/CreateWithdrawRequestTest.php`)