### PR TITLE
Create BusinessExceptionHandler

### DIFF
--- a/app/Domain/Exception/InvalidWithdrawMethodException.php
+++ b/app/Domain/Exception/InvalidWithdrawMethodException.php
@@ -15,4 +15,9 @@ class InvalidWithdrawMethodException extends BusinessException
     {
         return 'INVALID_WITHDRAW_METHOD';
     }
+
+    public function getHttpStatusCode(): int
+    {
+        return 400;
+    }
 }

--- a/app/Domain/Exception/RateLimitException.php
+++ b/app/Domain/Exception/RateLimitException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exception;
+
+class RateLimitException extends BusinessException
+{
+    public function __construct()
+    {
+        parent::__construct('Too many requests. Please try again later');
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'RATE_LIMIT_EXCEEDED';
+    }
+
+    public function getHttpStatusCode(): int
+    {
+        return 429;
+    }
+}

--- a/test/Unit/Domain/Exception/InvalidWithdrawMethodExceptionTest.php
+++ b/test/Unit/Domain/Exception/InvalidWithdrawMethodExceptionTest.php
@@ -39,10 +39,10 @@ class InvalidWithdrawMethodExceptionTest extends TestCase
     }
 
     #[Test]
-    public function hasDefaultHttpStatusCode(): void
+    public function hasHttpStatusCode400(): void
     {
         $exception = new InvalidWithdrawMethodException('TED');
 
-        $this->assertSame(422, $exception->getHttpStatusCode());
+        $this->assertSame(400, $exception->getHttpStatusCode());
     }
 }

--- a/test/Unit/Domain/Exception/RateLimitExceptionTest.php
+++ b/test/Unit/Domain/Exception/RateLimitExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Domain\Exception;
+
+use App\Domain\Exception\BusinessException;
+use App\Domain\Exception\RateLimitException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class RateLimitExceptionTest extends TestCase
+{
+    #[Test]
+    public function hasCorrectMessage(): void
+    {
+        $exception = new RateLimitException();
+
+        $this->assertSame('Too many requests. Please try again later', $exception->getMessage());
+    }
+
+    #[Test]
+    public function hasCorrectErrorCode(): void
+    {
+        $exception = new RateLimitException();
+
+        $this->assertSame('RATE_LIMIT_EXCEEDED', $exception->getErrorCode());
+    }
+
+    #[Test]
+    public function extendsBusinessException(): void
+    {
+        $exception = new RateLimitException();
+
+        $this->assertInstanceOf(BusinessException::class, $exception);
+    }
+
+    #[Test]
+    public function hasHttpStatusCode429(): void
+    {
+        $exception = new RateLimitException();
+
+        $this->assertSame(429, $exception->getHttpStatusCode());
+    }
+}


### PR DESCRIPTION
Closes #45 

This pull request introduces a new exception for rate limiting and updates the HTTP status code handling for withdraw method exceptions. It also adds corresponding unit tests to ensure correct behavior. The most important changes are grouped below by theme.

**Rate limiting support:**

* Added new `RateLimitException` class to handle cases when too many requests are made, including a specific error code and HTTP status code 429. (`app/Domain/Exception/RateLimitException.php`)
* Added unit tests for `RateLimitException` to verify the message, error code, inheritance, and HTTP status code. (`test/Unit/Domain/Exception/RateLimitExceptionTest.php`)

**Withdraw method exception updates:**

* Changed the HTTP status code returned by `InvalidWithdrawMethodException` from 422 to 400 and added a new method for this. (`app/Domain/Exception/InvalidWithdrawMethodException.php`)
* Updated unit test to check for HTTP status code 400 instead of 422 in `InvalidWithdrawMethodExceptionTest`. (`test/Unit/Domain/Exception/InvalidWithdrawMethodExceptionTest.php`)