### PR TITLE
Implement Idempotency Key middleware

### DIFF
--- a/app/Middleware/IdempotencyMiddleware.php
+++ b/app/Middleware/IdempotencyMiddleware.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use Hyperf\HttpMessage\Server\Response;
+use Hyperf\Redis\Redis;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class IdempotencyMiddleware implements MiddlewareInterface
+{
+    private const string CACHE_PREFIX = 'idempotency:';
+
+    private const int TTL_SECONDS = 86400; // 24 hours
+
+    public function __construct(
+        private readonly Redis $redis,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($request->getMethod() !== 'POST') {
+            return $handler->handle($request);
+        }
+
+        $idempotencyKey = $request->getHeaderLine('X-Idempotency-Key');
+
+        if ($idempotencyKey === '') {
+            return $handler->handle($request);
+        }
+
+        $cacheKey = self::CACHE_PREFIX . $idempotencyKey;
+
+        $cached = $this->redis->get($cacheKey);
+
+        if ($cached !== false) {
+            /** @var array{status: int, headers: array<string, string[]>, body: string} $data */
+            $data = json_decode($cached, true, 512, JSON_THROW_ON_ERROR);
+
+            $response = new Response();
+            $response = $response->withStatus($data['status']);
+            $response = $response->withContent($data['body']);
+
+            foreach ($data['headers'] as $name => $values) {
+                foreach ($values as $value) {
+                    $response = $response->withAddedHeader($name, $value);
+                }
+            }
+
+            return $response;
+        }
+
+        $response = $handler->handle($request);
+
+        $data = [
+            'status' => $response->getStatusCode(),
+            'headers' => $response->getHeaders(),
+            'body' => (string) $response->getBody(),
+        ];
+
+        $this->redis->set($cacheKey, json_encode($data, JSON_THROW_ON_ERROR), ['EX' => self::TTL_SECONDS]);
+
+        return $response;
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Controller\AccountWithdrawController;
 use App\Controller\HealthController;
+use App\Middleware\IdempotencyMiddleware;
 use App\Middleware\RateLimitMiddleware;
 use Hyperf\HttpServer\Router\Router;
 
@@ -12,7 +13,7 @@ Router::addRoute(['GET', 'POST', 'HEAD'], '/', 'App\Controller\IndexController@i
 Router::get('/health', [HealthController::class, 'check']);
 
 Router::post('/account/{accountId}/balance/withdraw', [AccountWithdrawController::class, 'withdraw'], [
-    'middleware' => [RateLimitMiddleware::class],
+    'middleware' => [IdempotencyMiddleware::class, RateLimitMiddleware::class],
 ]);
 
 Router::get('/favicon.ico', function () {

--- a/test/Unit/Middleware/IdempotencyMiddlewareTest.php
+++ b/test/Unit/Middleware/IdempotencyMiddlewareTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Unit\Middleware;
+
+use App\Middleware\IdempotencyMiddleware;
+use Hyperf\Redis\Redis;
+use HyperfTest\Support\UsesMockery;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * @internal
+ */
+class IdempotencyMiddlewareTest extends TestCase
+{
+    use UsesMockery;
+
+    private MockInterface|Redis $redis;
+
+    private IdempotencyMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->redis = Mockery::mock(Redis::class);
+        $this->middleware = new IdempotencyMiddleware($this->redis);
+    }
+
+    // -- non-POST requests pass through --
+
+    #[Test]
+    public function passesGetRequestWithoutIdempotencyCheck(): void
+    {
+        $request = $this->mockRequest(method: 'GET');
+        $handler = $this->mockHandler();
+        $expectedResponse = Mockery::mock(ResponseInterface::class);
+
+        $handler->shouldReceive('handle')
+            ->once()
+            ->with($request)
+            ->andReturn($expectedResponse);
+
+        $this->redis->shouldNotReceive('get');
+        $this->redis->shouldNotReceive('set');
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    // -- POST without header passes through --
+
+    #[Test]
+    public function passesPostRequestWithoutIdempotencyHeader(): void
+    {
+        $request = $this->mockRequest(method: 'POST', idempotencyKey: '');
+        $handler = $this->mockHandler();
+        $expectedResponse = Mockery::mock(ResponseInterface::class);
+
+        $handler->shouldReceive('handle')
+            ->once()
+            ->with($request)
+            ->andReturn($expectedResponse);
+
+        $this->redis->shouldNotReceive('get');
+        $this->redis->shouldNotReceive('set');
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    // -- first POST with idempotency key processes and caches --
+
+    #[Test]
+    public function processesFirstRequestAndCachesResponse(): void
+    {
+        $idempotencyKey = 'unique-key-123';
+        $cacheKey = 'idempotency:' . $idempotencyKey;
+        $responseBody = '{"id":"abc"}';
+
+        $request = $this->mockRequest(method: 'POST', idempotencyKey: $idempotencyKey);
+        $handler = $this->mockHandler();
+        $response = $this->mockResponse(status: 201, headers: ['Content-Type' => ['application/json']], body: $responseBody);
+
+        $handler->shouldReceive('handle')
+            ->once()
+            ->with($request)
+            ->andReturn($response);
+
+        $this->redis->shouldReceive('get')
+            ->once()
+            ->with($cacheKey)
+            ->andReturn(false);
+
+        $this->redis->shouldReceive('set')
+            ->once()
+            ->withArgs(function (string $key, string $value, array $options) use ($cacheKey) {
+                $this->assertSame($cacheKey, $key);
+                $this->assertSame(86400, $options['EX']);
+
+                $data = json_decode($value, true);
+                $this->assertSame(201, $data['status']);
+                $this->assertSame('{"id":"abc"}', $data['body']);
+                $this->assertSame(['application/json'], $data['headers']['Content-Type']);
+
+                return true;
+            })
+            ->andReturn(true);
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame($response, $result);
+    }
+
+    // -- second POST with same key returns cached response --
+
+    #[Test]
+    public function returnsCachedResponseForDuplicateRequest(): void
+    {
+        $idempotencyKey = 'unique-key-123';
+        $cacheKey = 'idempotency:' . $idempotencyKey;
+
+        $cached = json_encode([
+            'status' => 201,
+            'headers' => ['Content-Type' => ['application/json']],
+            'body' => '{"id":"abc"}',
+        ]);
+
+        $request = $this->mockRequest(method: 'POST', idempotencyKey: $idempotencyKey);
+        $handler = $this->mockHandler();
+
+        $this->redis->shouldReceive('get')
+            ->once()
+            ->with($cacheKey)
+            ->andReturn($cached);
+
+        $handler->shouldNotReceive('handle');
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame(201, $result->getStatusCode());
+        $this->assertSame('{"id":"abc"}', (string) $result->getBody());
+        $this->assertSame(['application/json'], $result->getHeader('Content-Type'));
+    }
+
+    // -- handler not called on cached response --
+
+    #[Test]
+    public function doesNotCallHandlerWhenCachedResponseExists(): void
+    {
+        $cached = json_encode([
+            'status' => 200,
+            'headers' => [],
+            'body' => '{}',
+        ]);
+
+        $request = $this->mockRequest(method: 'POST', idempotencyKey: 'any-key');
+        $handler = $this->mockHandler();
+
+        $this->redis->shouldReceive('get')
+            ->once()
+            ->andReturn($cached);
+
+        $handler->shouldNotReceive('handle');
+
+        $this->middleware->process($request, $handler);
+    }
+
+    // -- different keys produce different cache entries --
+
+    #[Test]
+    public function differentKeysAreCachedSeparately(): void
+    {
+        $capturedKeys = [];
+
+        $this->redis->shouldReceive('get')
+            ->twice()
+            ->withArgs(function (string $key) use (&$capturedKeys) {
+                $capturedKeys[] = $key;
+                return true;
+            })
+            ->andReturn(false);
+
+        $this->redis->shouldReceive('set')
+            ->twice()
+            ->andReturn(true);
+
+        $handler = $this->mockHandler();
+        $response = $this->mockResponse(status: 201, headers: [], body: '{}');
+        $handler->shouldReceive('handle')->andReturn($response);
+
+        $requestA = $this->mockRequest(method: 'POST', idempotencyKey: 'key-aaa');
+        $this->middleware->process($requestA, $handler);
+
+        $requestB = $this->mockRequest(method: 'POST', idempotencyKey: 'key-bbb');
+        $this->middleware->process($requestB, $handler);
+
+        $this->assertCount(2, $capturedKeys);
+        $this->assertSame('idempotency:key-aaa', $capturedKeys[0]);
+        $this->assertSame('idempotency:key-bbb', $capturedKeys[1]);
+    }
+
+    // -- TTL is 24 hours --
+
+    #[Test]
+    public function cachesResponseWith24HourTtl(): void
+    {
+        $request = $this->mockRequest(method: 'POST', idempotencyKey: 'ttl-test');
+        $handler = $this->mockHandler();
+        $response = $this->mockResponse(status: 200, headers: [], body: '{}');
+
+        $handler->shouldReceive('handle')->andReturn($response);
+
+        $this->redis->shouldReceive('get')->andReturn(false);
+
+        $this->redis->shouldReceive('set')
+            ->once()
+            ->withArgs(function (string $key, string $value, array $options) {
+                $this->assertSame(86400, $options['EX']);
+                return true;
+            })
+            ->andReturn(true);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    // -- PUT request passes through --
+
+    #[Test]
+    public function passesPutRequestWithoutIdempotencyCheck(): void
+    {
+        $request = $this->mockRequest(method: 'PUT', idempotencyKey: 'some-key');
+        $handler = $this->mockHandler();
+        $expectedResponse = Mockery::mock(ResponseInterface::class);
+
+        $handler->shouldReceive('handle')
+            ->once()
+            ->with($request)
+            ->andReturn($expectedResponse);
+
+        $this->redis->shouldNotReceive('get');
+        $this->redis->shouldNotReceive('set');
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    // -- DELETE request passes through --
+
+    #[Test]
+    public function passesDeleteRequestWithoutIdempotencyCheck(): void
+    {
+        $request = $this->mockRequest(method: 'DELETE', idempotencyKey: 'some-key');
+        $handler = $this->mockHandler();
+        $expectedResponse = Mockery::mock(ResponseInterface::class);
+
+        $handler->shouldReceive('handle')
+            ->once()
+            ->with($request)
+            ->andReturn($expectedResponse);
+
+        $this->redis->shouldNotReceive('get');
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame($expectedResponse, $result);
+    }
+
+    // -- helpers --
+
+    private function mockRequest(string $method, string $idempotencyKey = ''): MockInterface|ServerRequestInterface
+    {
+        $request = Mockery::mock(ServerRequestInterface::class);
+        $request->shouldReceive('getMethod')->andReturn($method);
+        $request->shouldReceive('getHeaderLine')
+            ->with('X-Idempotency-Key')
+            ->andReturn($idempotencyKey);
+
+        return $request;
+    }
+
+    private function mockHandler(): MockInterface|RequestHandlerInterface
+    {
+        return Mockery::mock(RequestHandlerInterface::class);
+    }
+
+    /**
+     * @param array<string, string[]> $headers
+     */
+    private function mockResponse(int $status, array $headers, string $body): MockInterface|ResponseInterface
+    {
+        $stream = Mockery::mock(StreamInterface::class);
+        $stream->shouldReceive('__toString')->andReturn($body);
+
+        $response = Mockery::mock(ResponseInterface::class);
+        $response->shouldReceive('getStatusCode')->andReturn($status);
+        $response->shouldReceive('getHeaders')->andReturn($headers);
+        $response->shouldReceive('getBody')->andReturn($stream);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Closes #54 

This pull request introduces a new idempotency middleware for POST requests, ensuring that duplicate requests with the same idempotency key return cached responses instead of being reprocessed. The middleware is integrated into the withdrawal endpoint and is thoroughly tested to verify correct behavior for various request scenarios.

Idempotency Middleware Implementation:

* Added `IdempotencyMiddleware` in `app/Middleware/IdempotencyMiddleware.php` to cache and return responses for POST requests with the same `X-Idempotency-Key` header, using Redis for storage with a 24-hour TTL.

Middleware Integration:

* Registered `IdempotencyMiddleware` in `config/routes.php` and applied it to the `/account/{accountId}/balance/withdraw` POST endpoint, ensuring idempotency for withdrawal actions. [[1]](diffhunk://#diff-0c213394893d5d3e9abc4b5622fec38857a8ddd518e46db4e5340f46894fd08aR7) [[2]](diffhunk://#diff-0c213394893d5d3e9abc4b5622fec38857a8ddd518e46db4e5340f46894fd08aL15-R16)

Testing:

* Added comprehensive unit tests in `test/Unit/Middleware/IdempotencyMiddlewareTest.php` to validate middleware behavior, including caching, cache retrieval, TTL, and handling of various HTTP methods.