### PR TITLE
fix: correct user protocol from JSON HTTPS to JSON HTTP in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ flowchart TB
     MAIL["📧 <b>Mailhog</b><br/><span style='font-size:12px;color:#94a3b8'>SMTP 1025 / UI 8025</span>"]:::ext
     JAE["📊 <b>Jaeger</b><br/><span style='font-size:12px;color:#94a3b8'>OTLP 4318 / UI 16686</span>"]:::ext
 
-    USER == "JSON HTTPS" ==> API
+    USER == "JSON HTTP" ==> API
     API ==>|"TCP 3306"| MYSQL
     API ==>|"TCP 6379"| REDIS
     CRON -->|"TCP 3306"| MYSQL
@@ -557,7 +557,6 @@ flowchart TB
 
     Middlewares ==> Controllers
     CTRL ==> UC_CREATE
-    CTRL -.-> FACT
     UC_CREATE ==> REPO_ACC & REPO_WD & TX & EVT
     UC_PROC ==> REPO_ACC & REPO_WD & TX & EVT
 


### PR DESCRIPTION
This pull request makes minor updates to the `README.md` flowchart diagrams to clarify protocol usage and simplify the representation of controller interactions.

* Flowchart protocol clarification:
  * Changed the label from `"JSON HTTPS"` to `"JSON HTTP"` to accurately reflect the protocol used between `USER` and `API`.

* Flowchart simplification:
  * Removed the indirect connection (`-.->`) between `CTRL` and `FACT` to streamline the controller flow diagram.