### PR TITLE
Add Adminer and Structurizr services to Docker Compose and update Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup up down test
+.PHONY: setup up down test adminer structurizr
 
 setup: ## Configura o .env com UID/GID do usuário atual e sobe os containers
 	@if [ ! -f .env ]; then cp .env.example .env; fi
@@ -20,3 +20,9 @@ cs-fix: ## Roda os testes unitários
 
 logs: ## Mostra apenas logs da aplicação (Monolog)
 	docker compose logs app -f
+
+adminer: ## Sobe o Adminer (DB UI) em http://localhost:8081
+	docker compose --profile tools up -d adminer
+
+structurizr: ## Sobe o Structurizr Lite (diagramas C4) em http://localhost:8080
+	docker compose --profile tools up -d structurizr

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A microservice for processing **PIX withdrawal** operations built with the **[Hy
 - [Quick Start](#quick-start)
 - [API Documentation](#api-documentation)
 - [Service URLs](#service-urls)
+- [Dev Tools (optional)](#dev-tools-optional)
 - [Technical Decisions](#technical-decisions)
 - [Architecture Diagrams](#architecture-diagrams)
   - [Hexagonal Architecture](#hexagonal-architecture)
@@ -324,6 +325,35 @@ curl -s -X POST http://localhost:9501/account/11111111-1111-1111-1111-1111111111
 | **Jaeger UI** | [http://localhost:16686](http://localhost:16686) | Distributed tracing dashboard |
 | **MySQL** | http://localhost:3306 | Database (`root` / `root`) |
 | **Redis** | http://localhost:6379 | Cache, rate limiting, idempotency storage |
+| **Adminer** | [http://localhost:8081](http://localhost:8081) | Lightweight DB UI (`--profile tools`) |
+| **Structurizr Lite** | [http://localhost:8080](http://localhost:8080) | Interactive C4 architecture diagrams (`--profile tools`) |
+
+---
+
+## Dev Tools (optional)
+
+**Adminer** and **Structurizr Lite** are declared in `docker-compose.yml` under the `tools` profile. They never start with a plain `make up` — only when explicitly requested.
+
+```bash
+make adminer      # DB UI    → http://localhost:8081
+make structurizr  # C4 diagrams → http://localhost:8080
+```
+
+### Adminer — Database UI
+
+Open [http://localhost:8081](http://localhost:8081) and log in with:
+
+| Field | Value |
+|---|---|
+| **System** | MySQL |
+| **Server** | `mysql` |
+| **Username** | `root` |
+| **Password** | `root` |
+| **Database** | `jsr_pix_withdrawal` |
+
+### Structurizr Lite — Architecture Diagrams
+
+Open [http://localhost:8080](http://localhost:8080) to browse the interactive C4 diagrams generated from [`workspace.dsl`](workspace.dsl).
 
 ---
 
@@ -459,13 +489,7 @@ flowchart TB
 
 ---
 
-> **Structurizr DSL** — This project includes a [`workspace.dsl`](workspace.dsl) file with the full C4 model (context, containers, components and dynamic views). To explore the interactive diagrams locally:
->
-> ```bash
-> docker run -it --rm -p 8080:8080 -v $(pwd):/usr/local/structurizr structurizr/lite
-> ```
->
-> Then open [http://localhost:8080](http://localhost:8080). The C4 Mermaid diagrams below are a simpler static snapshot of the same model.
+> **Structurizr DSL** — This project includes a [`workspace.dsl`](workspace.dsl) file with the full C4 model (context, containers, components and dynamic views). To explore the interactive diagrams locally, start the `structurizr` service (see [Dev Tools](#dev-tools-optional)) and open [http://localhost:8080](http://localhost:8080). The C4 Mermaid diagrams below are a simpler static snapshot of the same model.
 
 ### Context Diagram (C4 Level 1)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,5 +56,25 @@ services:
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
 
+  adminer:
+    container_name: jsr-pix-adminer
+    image: adminer
+    ports:
+      - "8081:8080"
+    depends_on:
+      - mysql
+    profiles:
+      - tools
+
+  structurizr:
+    container_name: jsr-pix-structurizr
+    image: structurizr/lite
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./:/usr/local/structurizr
+    profiles:
+      - tools
+
 volumes:
   mysql_data:


### PR DESCRIPTION
This pull request adds optional development tools to the project, specifically Adminer (a database UI) and Structurizr Lite (for interactive C4 architecture diagrams). These tools are integrated into the Docker Compose setup under a new `tools` profile and can be started individually using new Makefile targets. The documentation has been updated to explain their usage and access.

**Dev Tools Integration:**

* Added `adminer` and `structurizr` services to `docker-compose.yml` under the `tools` profile, allowing them to be run independently from the main application stack.
* Introduced new Makefile targets (`adminer` and `structurizr`) to start these services, and updated `.PHONY` to include them. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R23-R28)

**Documentation Updates:**

* Updated `README.md` to add a new section ("Dev Tools (optional)") describing how to start and use Adminer and Structurizr Lite, including login details and usage instructions.
* Added Adminer and Structurizr Lite to the list of service URLs in the documentation for easy reference.
* Revised the instructions for exploring architecture diagrams to reference the new Structurizr service instead of manual Docker commands.